### PR TITLE
Fixed broken dj.Table.drop

### DIFF
--- a/+dj/Table.m
+++ b/+dj/Table.m
@@ -85,9 +85,9 @@ classdef (Sealed) Table < handle
         end
         
         
-            if isempty(self.schema.prefix) 
         function name = fullTableName(self)
             % table name with database, escaped in backquotes
+            if isempty(self.schema.prefix) 
                 name = sprintf('`%s`.`%s`', self.schema.dbname, self.info.name);
             else
                 name = sprintf('`%s`.`%s/%s`', self.schema.dbname, self.schema.prefix, self.info.name);


### PR DESCRIPTION
The current implementation of dj.Table.drop is broken (at least on R2012b). The syntax `get.fullTableName(dj.Table('foo'))` is invalid. 

Converted properties fullTableName/plainTableName to functions, which is a simple fix for this bug.
