### PR TITLE
Correct bracketing of where clause when struct arrays are used as restriction

### DIFF
--- a/+dj/GeneralRelvar.m
+++ b/+dj/GeneralRelvar.m
@@ -686,7 +686,7 @@ for arg = restrictions
             else
                 if ~isempty(cond)
                     % normal restricton
-                    clause = sprintf('%s AND %s', clause, struct2cond(cond, selfAttrs));
+                    clause = sprintf('%s AND (%s)', clause, struct2cond(cond, selfAttrs));
                 else
                     if isempty(cond)
                         % restrictor has common attributes but is empty:


### PR DESCRIPTION
The following relvar wasn't translated properly into SQL due to a missing parenthesis when `keys` was a structure array:

```
relvar & 'field = 1' & keys
```
