### PR TITLE
Escaping of string literals in struct2cond

### DIFF
--- a/+dj/GeneralRelvar.m
+++ b/+dj/GeneralRelvar.m
@@ -734,7 +734,8 @@ else
                 if header(iField).isString
                     assert( ischar(value), ...
                         'Value for key.%s must be a string', field{1})
-                    value=sprintf('"%s"',value);
+                    % Escape ' characters in string literal
+                    value = sprintf('''%s''', strrep(value, '''', ''''''));
                 else
                     assert(isnumeric(value), ...
                         'Value for key.%s must be numeric', field{1});


### PR DESCRIPTION
String literals in `struct2cond` are not escaped correctly. Queries like

```
acq.EventstringsUnique(struct('eventstring', 'foo "bar"'))
```

will cause an SQL error because string literals are enclosed in double quotation marks and the user-supplied string is not escaped in any way.
The attached patch changes this behavior twofold:
1. String literals are now enclosed in single quotation marks. This is closer to the SQL standard and makes the code independent from the MySQL server mode
2. Single quotation marks are correctly escaped using two single quotation mark characters

With this patch, both

```
acq.EventstringsUnique(struct('eventstring', 'foo "bar"'))
```

and

```
acq.EventstringsUnique(struct('eventstring', 'foo ''bar'''))
```

create valid SQL statements and the expected query results.
