### PR TITLE
Fix selection of dependent tuples in dj.BaseRelvar.del()

### DIFF
--- a/+dj/BaseRelvar.m
+++ b/+dj/BaseRelvar.m
@@ -79,7 +79,7 @@ classdef BaseRelvar < dj.GeneralRelvar
                 for i=1:length(rels)
                     for ix = cellfun(@(child) find(strcmp(child,list)), [rels(i).tab.children rels(i).tab.referencing])
                         if restrictByMe(i)
-                            rels(ix).restrict(rels(i));
+                            rels(ix).restrict(pro(rels(i)));
                         else
                             rels(ix).restrict(rels(i).restrictions{:});
                         end


### PR DESCRIPTION
- When deleting tuples from a parent table, all affected tuples
  from dependent tables also have to be deleted.
- The dependency relationship is based on the primary key fields
  of the parent table.
- When restricting dependent RelVars in del(), the restricting
  RelVar has to be projected onto its set of primary key fields.
- Otherwise, the natural join can be too restrictive because of accidental matches on fields with identical names that are not in the primary key of the parent table. In this case, some dependent tuples will be missed and the del() operation will fail at the level of MySQL

I'm submitting a PR because the dependency resolution is somewhat complex and del() a dangerous method. Would be great to get a second opinion, especially Dimitri's as the original author of the code.
