### PR TITLE
commented self.insert for new classes

### DIFF
--- a/+dj/Schema.m
+++ b/+dj/Schema.m
@@ -150,7 +150,7 @@ classdef Schema < handle
                 end
                 fprintf(f, '\n\n\t\tfunction makeTuples(self, key)\n');
                 fprintf(f, '\t\t%%!!! compute missing fields for key here\n');
-                fprintf(f, '\t\t\t%%self.insert(key)     %% This line inserts the key\n');
+                fprintf(f, '\t\t\t%%self.insert(key)\n');
                 fprintf(f, '\t\tend\n');
                 fprintf(f, '\tend\n');
             end

--- a/+dj/Schema.m
+++ b/+dj/Schema.m
@@ -150,7 +150,7 @@ classdef Schema < handle
                 end
                 fprintf(f, '\n\n\t\tfunction makeTuples(self, key)\n');
                 fprintf(f, '\t\t%%!!! compute missing fields for key here\n');
-                fprintf(f, '\t\t\tself.insert(key)\n');
+                fprintf(f, '\t\t\t%%self.insert(key)     %% This line inserts the key\n');
                 fprintf(f, '\t\tend\n');
                 fprintf(f, '\tend\n');
             end


### PR DESCRIPTION
This requires the user to uncomment the `self.insert(key)` line in a new class definition created via `dj.new`. Previously, when a MATLAB class is created for a table that is populated in Python, the table could be immediately populated from MATLAB. Population via MATLAB would fail if there are any secondary attributes in the table, but for parents of subtables, it would succeed in entering parent tuples without populating the subtable, thus preventing subsequent population via Python.  This change removes the opportunity for these sorts of mistakes.