### PR TITLE
Escape backslash in dj.ask

### DIFF
--- a/+dj/ask.m
+++ b/+dj/ask.m
@@ -4,6 +4,7 @@ if nargin<=1
 end
 choice = '';    
 choiceStr = sprintf('/%s',choices{:});
+question = strrep(question, '\', '\\'); % Backslash is a special character in INPUT, needs to be escaped.
 while ~ismember(choice, lower(choices))
     choice = lower(input([question ' (' choiceStr(2:end) ') > '], 's'));
 end


### PR DESCRIPTION
Matlab's input() function uses the backslash as a special character, so
questions containing paths do not get displayed correctly on Windows
unless backslashes are escaped.