### PR TITLE
Appropriate handling of CTRL-C during populate/parpopulate

### DIFF
--- a/+dj/AutoPopulate.m
+++ b/+dj/AutoPopulate.m
@@ -159,6 +159,19 @@ classdef AutoPopulate < handle
         function taskCore(self, key)
             % The work unit that is submitted to the cluster
             % or executed locally
+            
+            function cleanup(self, key)
+                tuple = fetch(self.jobs & self.makeJobKey(key), 'status');
+                if ~isempty(tuple) && strcmp(tuple.status, 'reserved')
+                    self.schema.conn.cancelTransaction
+                    self.setJobStatus(key, 'error', 'Populate interrupted', []);
+                end
+            end
+            % this is guaranteed to be executed when the function is 
+            % terminated even if by KeyboardInterrupt (CTRL-C)
+            % When used with onCleanup,  the function itself cannot contain upvalues
+            obj = onCleanup(@() cleanup(self, key));
+            
             self.schema.conn.startTransaction()
             try
                 self.makeTuples(key)

--- a/+dj/AutoPopulate.m
+++ b/+dj/AutoPopulate.m
@@ -161,9 +161,9 @@ classdef AutoPopulate < handle
             % or executed locally
             
             function cleanup(self, key)
+                self.schema.conn.cancelTransaction
                 tuple = fetch(self.jobs & self.makeJobKey(key), 'status');
                 if ~isempty(tuple) && strcmp(tuple.status, 'reserved')
-                    self.schema.conn.cancelTransaction
                     self.setJobStatus(key, 'error', 'Populate interrupted', []);
                 end
             end

--- a/+dj/version.m
+++ b/+dj/version.m
@@ -1,7 +1,7 @@
 function varargout = version
 % report DataJoint version
 
-v = struct('major',2,'minor',8,'bugfix',1);
+v = struct('major',2,'minor',8,'bugfix',2);
 
 if nargout
     varargout{1}=v;


### PR DESCRIPTION
Fixed #59 
* When KeyboardInterrupt (`CTRL-C`) is issued in the middle of `populate`/`parpopulate`, it now appropriately closes any open transaction before returning control to the user
* If `CTRL-C` occured during `parpopulate`, it will also update the job status appropriately to `error` with useful error message to indicate the interrupt in the `populate` process. Previously, this would have left the job status hanging at `reserved`.