### PR TITLE
Proper handling of Windows path in `dj.ask` prompts

### DIFF
--- a/+dj/Table.m
+++ b/+dj/Table.m
@@ -485,7 +485,10 @@ classdef Table < handle
             % This method is useful if the table definition has been
             % changed by other means than the regular datajoint definition
             % process.
-            path = which(self.className);
+            
+            % escape backslashes in pathname for proper display - only
+            % relevant on Windows
+            path = strrep(which(self.className), '\', '\\');
             if isempty(path)
                 fprintf('File %s.m is not found\n', self.className);
             else

--- a/+dj/ask.m
+++ b/+dj/ask.m
@@ -4,7 +4,6 @@ if nargin<=1
 end
 choice = '';    
 choiceStr = sprintf('/%s',choices{:});
-question = strrep(question, '\', '\\'); % Backslash is a special character in INPUT, needs to be escaped.
 while ~ismember(choice, lower(choices))
     choice = lower(input([question ' (' choiceStr(2:end) ') > '], 's'));
 end


### PR DESCRIPTION
Fix #55, #57 
* `dj.ask` does not format it's prompt, allowing special escape sequences (e.g. `\n`) to be used, reverting changes made in #56, and thus fixing #57.
* In `Table.syncDef`, file path string containing backslashes (`\`) on Windows was not appropriately escaped, resulting in disappearing `\` with potentially weird formatting as observed in #55. 