### PR TITLE
Add proper handling of CTRL-C during delete

### DIFF
--- a/+dj/AutoPopulate.m
+++ b/+dj/AutoPopulate.m
@@ -170,7 +170,7 @@ classdef AutoPopulate < handle
             % this is guaranteed to be executed when the function is 
             % terminated even if by KeyboardInterrupt (CTRL-C)
             % When used with onCleanup,  the function itself cannot contain upvalues
-            obj = onCleanup(@() cleanup(self, key));
+            cleanupObject = onCleanup(@() cleanup(self, key));
             
             self.schema.conn.startTransaction()
             try

--- a/+dj/Relvar.m
+++ b/+dj/Relvar.m
@@ -59,7 +59,7 @@ classdef Relvar < dj.GeneralRelvar & dj.Table
             
             % this is guaranteed to be executed when the function is 
             % terminated even if by KeyboardInterrupt (CTRL-C)
-            obj = onCleanup(@() cleanup(self));
+            cleanupObject = onCleanup(@() cleanup(self));
             
             self.schema.conn.cancelTransaction  % exit ongoing transaction, if any
             


### PR DESCRIPTION
Related to #59 and #29, KeyboardInterrupt (`CTRL-C`) during `delete` is now properly handled, canceling any hanging transaction before returning the control to the user.