### PR TITLE
Make dj.new invoke dj.createSchema if package is missing

### DIFF
--- a/+dj/createSchema.m
+++ b/+dj/createSchema.m
@@ -1,4 +1,10 @@
-function newSchema
+function createSchema(package)
+% DJ.CREATESCHEMA - interactively create a new DataJoint schema
+%
+% INPUT:
+%   (optional) package - name of the package to be associated with the
+%   schema
+
 
 dbname = input('Enter database name >> ','s');
 
@@ -18,7 +24,15 @@ else
         disp 'database created'
     end
     
-    folder = uigetdir('./','Select of create package folder');
+    if nargin < 1
+        folder = uigetdir('./','Select a package folder');
+    else
+        folder = uigetdir('./', sprintf('Select folder to create package %s in', ['+', package]));
+        if folder
+            folder = fullfile(folder, ['+', package]);
+            mkdir(folder)
+        end
+    end
     
     if ~folder
         disp 'No package selected.  Cancelled.'

--- a/+dj/new.m
+++ b/+dj/new.m
@@ -15,7 +15,12 @@ end
 
 schemaFunction = [className(1:p-1) '.getSchema'];
 if isempty(which(schemaFunction))
-    throwAsCaller(MException('DataJoint:makeClass', 'Cannot find %s', schemaFunction))
+    fprintf('Package %s is missing. Calling dj.createSchema...\n', className(1:p-1))
+    % this wouldn't work well if nested package is given
+    dj.createSchema(className(1:p-1))
+    if isempty(which(schemaFunction))
+        throwAsCaller(MException('DataJoint:makeClass', 'Cannot find %s', schemaFunction))
+    end
 end
 
 makeClass(eval(schemaFunction), className(p+1:end))


### PR DESCRIPTION
Fix issue #67 

When one uses `dj.new` and the specified package is not defined, `dj.createSchema` is invoked to assist with the process of schema creation. `dj.createSchema` was modified to accept an optional package name such that if given, the folder UI will be used to *select a folder to create the target package in*. If no package name is specified, then the user is expected to select an existing package (or one created inside the UI). This greatly simplifies the process of very first table creation as user only has to know how to use `dj.new`.