### PR TITLE
fixed issue #81: workaround for MATLAB bug in struct2table for table display

### DIFF
--- a/+dj/GeneralRelvar.m
+++ b/+dj/GeneralRelvar.m
@@ -87,7 +87,8 @@ classdef GeneralRelvar < matlab.mixin.Copyable
                 end
                 maxRows = dj.set('maxPreviewRows');
                 tuples = self.fetch(attrList{:}, sprintf('LIMIT %d', maxRows+1));
-                tabl = struct2table(tuples(1:min(end,maxRows)));
+                tuples = arrayfun(@(r) structfun(@rep, r, 'uni', false), tuples);
+                tabl = struct2table(tuples);
                 funs = {
                     @(x) x
                     @upper
@@ -102,6 +103,16 @@ classdef GeneralRelvar < matlab.mixin.Copyable
             
             % print the total number of tuples
             fprintf('%d tuples (%.3g s)\n\n', nTuples, toc)
+            
+
+            function r = rep(r)
+                % replace empty strings with a single space
+                if ischar(r) && isempty(r)
+                    r = ' ';
+                end
+            end
+            
+            
         end
         
         function view(self, varargin)


### PR DESCRIPTION
This fix compensates for a bug in MATLAB's struct2table function, which chokes when one of the fields is an empty string.