### PR TITLE
cosmetic fix -- suppressed output from dj.lib.isString

### DIFF
--- a/+dj/+lib/isString.m
+++ b/+dj/+lib/isString.m
@@ -1,5 +1,5 @@
 function ret = isString(s)
 % a MATLAB version-safe function that tells returns true if 
 % argument is a string or a character array
-ret = ischar(s) || exist('isstring', 'builtin') && isstring(s) && isscalar(s)
+ret = ischar(s) || exist('isstring', 'builtin') && isstring(s) && isscalar(s);
 end


### PR DESCRIPTION
A semicolon was accidentally left out in the previous commit, resulting in excessive output.