### PR TITLE
Update createSchema message and increment version

### DIFF
--- a/+dj/createSchema.m
+++ b/+dj/createSchema.m
@@ -25,8 +25,10 @@ else
     end
     
     if nargin < 1
+        disp 'Please select a package folder. Opening UI...'
         folder = uigetdir('./','Select a package folder');
     else
+        fprintf('Please select folder to create package %s in. Opening UI...\n', ['+', package])
         folder = uigetdir('./', sprintf('Select folder to create package %s in', ['+', package]));
         if folder
             folder = fullfile(folder, ['+', package]);

--- a/+dj/version.m
+++ b/+dj/version.m
@@ -1,7 +1,7 @@
 function varargout = version
 % report DataJoint version
 
-v = struct('major',3,'minor',1,'bugfix',0);
+v = struct('major',3,'minor',2,'bugfix',0);
 
 if nargout
     varargout{1}=v;


### PR DESCRIPTION
* The title for `uigetdir` doesn't show up for some combination of MATLAB and OS, thereby sometimes making it very difficult for the user to know what is expected when the file UI opens. `createSchema` now prints out helpful message to aid this situation.

* Increment version number to `3.2.0` in preparation of a new release.