### PR TITLE
Bug fix on startsWith usage

### DIFF
--- a/+dj/+internal/Master.m
+++ b/+dj/+internal/Master.m
@@ -7,7 +7,7 @@ classdef Master < handle
             % find classnames that begin with me and are dj.Part
             info = meta.class.fromName(class(self));
             classNames = {info.ContainingPackage.ClassList.Name};
-            list = cellfun(@feval, classNames(startsWith(classNames, class(self))), 'uni', false);
+            list = cellfun(@feval, classNames(dj.lib.startsWith(classNames, class(self))), 'uni', false);
             list = list(cellfun(@(x) isa(x, 'dj.Part'), list));
         end
     end

--- a/+dj/+lib/startsWith.m
+++ b/+dj/+lib/startsWith.m
@@ -1,0 +1,8 @@
+function ret = startsWith(s, pattern)
+% a MATLAB version-safe function that checks whether the string s
+% starts with the given pattern
+
+ret = strncmp(s, pattern, length(pattern));
+
+end
+


### PR DESCRIPTION
Fix issue #107 

* Now we use our own implementation of `startsWith` as made available in `dj.lib.startsWith`