### PR TITLE
Implement TableAccessor and add a TableAccessor property to Schema.

### DIFF
--- a/+dj/+internal/TableAccessor.m
+++ b/+dj/+internal/TableAccessor.m
@@ -23,9 +23,9 @@ classdef TableAccessor < dynamicprops
         
         function self = TableAccessor(schema)
             for className = schema.classNames
-                splitName = strsplit(className{1},'.');
+                splitName = strsplit(className{1}, '.');
                 name = splitName{2};
-                addprop(self,name);
+                addprop(self, name)
                 self.(name) = dj.Relvar(className{1});
             end
         end

--- a/+dj/+internal/TableAccessor.m
+++ b/+dj/+internal/TableAccessor.m
@@ -1,0 +1,34 @@
+% dj.internal.TableAccessor allows access to tables without requiring the
+% creation of classes.
+%
+% Initialization:
+%    v = dj.internal.TableAccessor(schema);
+% 
+% MATLAB does not allow the creation of classes without creating
+% corresponding classes.
+%
+% TableAccessor provides a way to access all tables in a schema without
+% having to first create the classes. A TableAccessor object is created as
+% a property of a schema during the schema's creation. This property is
+% named schema.v for 'virtual class generator.' The TableAccessor v itself
+% has properties that refer to the tables of the schema.
+%
+% For example, one can access the Session table using schema.v.Session with
+% no need for any Session class to exist in Matlab. Tab completion of table
+% names is possible because the table names are added as dynamic properties
+% of TableAccessor.
+classdef TableAccessor < dynamicprops
+    
+    methods
+        
+        function self = TableAccessor(schema)
+            for className = schema.classNames
+                splitName = strsplit(className{1},'.');
+                name = splitName{2};
+                addprop(self,name);
+                self.(name) = dj.Relvar(className{1});
+            end
+        end
+    end
+    
+end

--- a/+dj/Schema.m
+++ b/+dj/Schema.m
@@ -11,6 +11,7 @@ classdef Schema < handle
         loaded = false
         tableNames   % tables indexed by classNames
         headers    % dj.internal.Header objects indexed by table names
+        v          % virtual class generator
     end
     
     
@@ -52,6 +53,7 @@ classdef Schema < handle
             self.conn.addPackage(dbname, package)
             self.headers    = containers.Map('KeyType','char','ValueType','any');
             self.tableNames = containers.Map('KeyType','char','ValueType','char');
+            self.v = dj.internal.TableAccessor(self);
         end
         
         

--- a/+dj/Schema.m
+++ b/+dj/Schema.m
@@ -1,5 +1,14 @@
 % dj.Schema - manages information about database tables and their dependencies
-% Complete documentation is available at <a href=https://github.com/datajoint/datajoint-matlab/wiki>Datajoint wiki</a>
+%
+% A TableAccessor object is created as a property of a schema during the
+% schema's creation. This property is named schema.v for
+% 'virtual class generator.' The TableAccessor v itself has properties that
+% refer to the tables of the schema. For example, one can access the
+% Session table using schema.v.Session with no need for any Session class
+% to exist in Matlab. Tab completion of table names is possible because the
+% table names are added as dynamic properties of TableAccessor.
+%
+%Complete documentation is available at <a href=https://github.com/datajoint/datajoint-matlab/wiki>Datajoint wiki</a>
 
 classdef Schema < handle
     


### PR DESCRIPTION
This allows access to tables without generating classes in MATLAB. Moving toward clean interaction without creating files. Previously, one would have to use `dj.new` for each table you want to interact with. TableAccessor provides a way to access all tables in a schema without having to first create the classes. A TableAccessor object is created as a property of a schema during the schema's creation. This property is named schema.v for 'virtual class generator.' The TableAccessor v itself has properties that refer to the tables of the schema.

Example:
```matlab
schema = ephys.getSchema;
scanData = fetch(schema.v.Session * schema.v.Scan & 'session_date > "2018-01-01"')
```