### PR TITLE
connection/jobs table update: track server connid, add user/id to jobs table

### DIFF
--- a/+dj/+internal/AutoPopulate.m
+++ b/+dj/+internal/AutoPopulate.m
@@ -149,8 +149,10 @@ classdef AutoPopulate < dj.internal.UserRelation
             %   key=null          : blob                  # structure containing the key
             %   error_message=""  : varchar(1023)         # error message returned if failed
             %   error_stack=null  : blob                  # error stack if failed
+            %   user=""           : varchar(255)          # database user
             %   host=""           : varchar(255)          # system hostname
             %   pid=0             : int unsigned          # system process id
+            %   connection_id=0   : bigint unsigned       # connection_id()
             %   timestamp=CURRENT_TIMESTAMP : timestamp    # automatic timestamp
             %
             % A job is considered to be available when <package>.Jobs contains
@@ -382,7 +384,7 @@ classdef AutoPopulate < dj.internal.UserRelation
                 end
             end
             
-            
+
             function jobKey = addJobInfo(jobKey)
                 if all(ismember({'host','pid'},self.jobs.header.names))
                     try
@@ -390,8 +392,10 @@ classdef AutoPopulate < dj.internal.UserRelation
                     catch
                         [~,host] = system('hostname');
                     end
+                    jobKey.user = self.schema.conn.user
                     jobKey.host = strtrim(host);
                     jobKey.pid = feature('getpid');
+                    jobKey.connection_id = self.schema.conn.serverId;
                 end
                 if ismember('error_key', self.jobs.header.names)
                     % for backward compatibility with versions prior to 2.6.3
@@ -420,8 +424,10 @@ classdef AutoPopulate < dj.internal.UserRelation
             fprintf(f, 'key=null           : blob                     # structure containing the key\n');
             fprintf(f, 'error_message=""   : varchar(1023)            # error message returned if failed\n');
             fprintf(f, 'error_stack=null   : blob                     # error stack if failed\n');
+            fprintf(f, 'user=""            : varchar(255)             # database user\n');
             fprintf(f, 'host=""            : varchar(255)             # system hostname\n');
             fprintf(f, 'pid=0              : int unsigned             # system process id\n');
+            fprintf(f, 'connection_id=0    : bigint unsigned          # connection_id()\n');
             fprintf(f, 'timestamp=CURRENT_TIMESTAMP : timestamp       # automatic timestamp\n');
             fprintf(f, '%%}\n\n');
             fprintf(f, 'classdef Jobs < dj.Jobs\n');

--- a/+dj/Connection.m
+++ b/+dj/Connection.m
@@ -6,7 +6,8 @@ classdef Connection < handle
         initQuery    % initializing function or query executed for each new session
         use_tls
         inTransaction = false
-        connId       % connection handle
+        connId       % MyM connection handle
+        serverId     % server connection ID
         packages     % maps database names to package names
         
         % dependency lookups by table name
@@ -168,6 +169,9 @@ classdef Connection < handle
                 if ~isempty(self.initQuery)
                     self.query(self.initQuery);
                 end
+
+                self.serverId = self.query('SELECT CONNECTION_ID() as id').id;
+
             end
             v = varargin;
             if dj.set('bigint_to_double')

--- a/+dj/conn.m
+++ b/+dj/conn.m
@@ -117,5 +117,7 @@ if ~connObj.isConnected
 end
 
 if nargout==0
-    query(connObj, 'SELECT connection_id()')
+    fprintf('server connection id: %d\n', connObj.serverId)
+end
+
 end


### PR DESCRIPTION
to fix issue #87, #275 (add user/server connection to jobs table).

ideally, connection ID would be directly available via MyM; for the moment,
hack in a query to retrieve connection ID on connection and use this for
jobs table logging.