### PR TITLE
Patch virtual classes regression bug, attribute comment parsing bug, and add issue templates

### DIFF
--- a/+dj/+internal/TableAccessor.m
+++ b/+dj/+internal/TableAccessor.m
@@ -26,19 +26,7 @@ classdef TableAccessor < dynamicprops
                 splitName = strsplit(className{1}, '.');
                 name = splitName{2};
                 addprop(self, name);
-                tableName = schema.tableNames(className{1});
-                tierClass = 'dj.Manual';
-                for k=1:numel(dj.Schema.tierPrefixes)
-                    tierCharLen = length(dj.Schema.tierPrefixes{k});
-                    if tierCharLen > 0 && length(tableName) >= tierCharLen && ...
-                            ~isempty(regexp(dj.Schema.tierPrefixes{k}, ...
-                                            tableName(1:tierCharLen), 'ONCE'))
-                        tierClass = dj.Schema.tierClasses{k};
-                        break;
-                    end
-                end
-                tierClass = strsplit(tierClass, '.');
-                self.(name) = dj.(tierClass{2})(className{1});
+                self.(name) = dj.internal.UserRelation(className{1});
             end
         end
     end

--- a/+dj/Computed.m
+++ b/+dj/Computed.m
@@ -1,5 +1,10 @@
 classdef Computed < dj.internal.AutoPopulate
     % defines a computed table
+    properties(Constant)
+        tierRegexp = ['(?<computed>' ...
+                      dj.Schema.tierPrefixes{strcmp(dj.Schema.allowedTiers, 'computed')} ...
+                      dj.Schema.baseRegexp ')']
+    end
     methods
         function self = Computed(varargin)
             self@dj.internal.AutoPopulate(varargin{:})

--- a/+dj/ERD.m
+++ b/+dj/ERD.m
@@ -118,10 +118,12 @@ classdef ERD < handle
             
             self.makeGraph
             
-            rege = cellfun(@(s) sprintf('^`[a-z]\\w*`\\.`%s[a-z]\\w*`$',s), dj.Schema.tierPrefixes, 'uni', false);
+            rege = cellfun(@(s) sprintf('^`[a-z]\\w*`\\.`%s[a-z]\\w*`$',s), ...
+                           dj.Schema.tierPrefixes, 'uni', false);
             rege{end+1} = '^`[a-z]\w*`\.`\W?\w+__\w+`$';   % for part tables
             rege{end+1} = '^\d+$';  % for numbered nodes
-            tiers = cellfun(@(l) find(~cellfun(@isempty, regexp(l, rege)), 1, 'last'), self.graph.Nodes.Name);
+            tiers = cellfun(@(l) find(~cellfun(@isempty, regexp(l, rege)), 1, 'last'), ...
+                            self.graph.Nodes.Name);
             colormap(0.3+0.7*[
                 0.3 0.3 0.3
                 0.0 0.5 0.0
@@ -180,8 +182,10 @@ classdef ERD < handle
                 ref = [];
                 from = [];
             else
-                from = arrayfun(@(item) find(strcmp(item.from, list)), self.conn.foreignKeys, 'uni', false);
-                ref = arrayfun(@(item) find(strcmp(item.ref, list)), self.conn.foreignKeys, 'uni', false);
+                from = arrayfun(@(item) find(strcmp(item.from, list)), ...
+                                self.conn.foreignKeys, 'uni', false);
+                ref = arrayfun(@(item) find(strcmp(item.ref, list)), ...
+                               self.conn.foreignKeys, 'uni', false);
                 ix = ~cellfun(@isempty, from) & ~cellfun(@isempty, ref);
                 if ~isempty(ref)
                     primary = [self.conn.foreignKeys(ix).primary];
@@ -212,6 +216,18 @@ classdef ERD < handle
             end
         end
     end
-    
-    
+    methods(Static)
+        function tier = getTier(tableName)
+            tier = [];
+            for pattern = cellfun(@(x) dj.(x(4:end)).tierRegexp, dj.Schema.tierClasses, ...
+                                  'uni', false)
+                fieldInfo = regexp(tableName, pattern{1}, 'names');
+                if ~isempty(fieldInfo)
+                    tier = fieldnames(fieldInfo);
+                    tier = tier{1};
+                    break
+                end
+            end
+        end
+    end
 end

--- a/+dj/Imported.m
+++ b/+dj/Imported.m
@@ -1,5 +1,10 @@
 classdef Imported < dj.internal.AutoPopulate
     % defines an imported table
+    properties(Constant)
+        tierRegexp = ['(?<imported>' ...
+                      dj.Schema.tierPrefixes{strcmp(dj.Schema.allowedTiers, 'imported')} ...
+                      dj.Schema.baseRegexp ')']
+    end
     methods
         function self = Imported(varargin)
             self@dj.internal.AutoPopulate(varargin{:})

--- a/+dj/Jobs.m
+++ b/+dj/Jobs.m
@@ -1,4 +1,9 @@
 classdef Jobs < dj.Relvar
+    properties(Constant)
+        tierRegexp = ['(?<job>' ...
+                      dj.Schema.tierPrefixes{strcmp(dj.Schema.allowedTiers, 'job')} ...
+                      dj.Schema.baseRegexp ')']
+    end
     methods
         function self = Jobs(varargin)
             self@dj.Relvar(varargin{:})

--- a/+dj/Lookup.m
+++ b/+dj/Lookup.m
@@ -1,6 +1,10 @@
 classdef Lookup < dj.internal.UserRelation
     % defines a lookup table
-    
+    properties(Constant)
+        tierRegexp = ['(?<lookup>' ...
+                      dj.Schema.tierPrefixes{strcmp(dj.Schema.allowedTiers, 'lookup')} ...
+                      dj.Schema.baseRegexp ')']
+    end
     methods
         function self = Lookup(varargin)
             self@dj.internal.UserRelation(varargin{:})

--- a/+dj/Manual.m
+++ b/+dj/Manual.m
@@ -1,5 +1,10 @@
 classdef Manual < dj.internal.UserRelation
 % Defines a manual table
+    properties(Constant)
+        tierRegexp = ['(?<manual>' ...
+                      dj.Schema.tierPrefixes{strcmp(dj.Schema.allowedTiers, 'manual')} ...
+                      dj.Schema.baseRegexp ')']
+    end
     methods
         function self = Manual(varargin)
             self@dj.internal.UserRelation(varargin{:})

--- a/+dj/Schema.m
+++ b/+dj/Schema.m
@@ -46,6 +46,7 @@ classdef Schema < handle
         allowedTiers = {'lookup' 'manual' 'imported' 'computed' 'job'}
         tierPrefixes = {'#', '', '_', '__', '~'}
         tierClasses = {'dj.Lookup' 'dj.Manual' 'dj.Imported' 'dj.Computed' 'dj.Jobs'}
+        baseRegexp = '[a-z][a-z0-9]*(_[a-z][a-z0-9]*)*'
     end
     
     

--- a/+dj/version.m
+++ b/+dj/version.m
@@ -1,7 +1,7 @@
 function varargout = version
 % report DataJoint version
 
-v = struct('major',3,'minor',4,'bugfix',0);
+v = struct('major',3,'minor',4,'bugfix',1);
 
 if nargout
     varargout{1}=v;

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug, awaiting-triage'
+assignees: ''
+
+---
+
+## Bug Report
+
+### Description
+A clear and concise description of what is the overall operation that is intended to be performed that resulted in an error.
+
+### Reproducibility
+Include:
+- OS (WIN | MACOS | Linux)
+- MATLAB Version
+- MySQL Version
+- MySQL Deployment Strategy (local-native | local-docker | remote)
+- DataJoint Version
+- Minimum number of steps to reliably reproduce the issue
+- Complete error stack as a result of evaluating the above steps
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Additional Research and Context
+Add any additional research or context that was conducted in creating this report.
+
+For example:
+- Related GitHub issues and PR's either within this repository or in other relevant repositories.
+- Specific links to specific lines or a focus within source code.
+- Relevant summary of Maintainers development meetings, milestones, projects, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Suggest an idea for a new feature
+title: ''
+labels: 'enhancement, awaiting-triage'
+assignees: ''
+
+---
+
+## Feature Request
+
+### Problem
+A clear and concise description how this idea has manifested and the context. Elaborate on the need for this feature and/or what could be improved. Ex. I'm always frustrated when [...]
+
+### Requirements
+A clear and concise description of the requirements to satisfy the new feature. Detail what you expect from a successful implementation of the feature. Ex. When using this feature, it should [...]
+
+### Justification
+Provide the key benefits in making this a supported feature. Ex. Adding support for this feature would ensure [...]
+
+### Alternative Considerations
+Do you currently have a work-around for this? Provide any alternative solutions or features you've considered.
+
+### Related Errors
+Add any errors as a direct result of not exposing this feature.
+
+Please include steps to reproduce provided errors as follows:
+- OS (WIN | MACOS | Linux)
+- MATLAB Version
+- MySQL Version
+- MySQL Deployment Strategy (local-native | local-docker | remote)
+- DataJoint Version
+- Minimum number of steps to reliably reproduce the issue
+- Complete error stack as a result of evaluating the above steps
+
+### Screenshots
+If applicable, add screenshots to help explain your feature.
+
+### Additional Research and Context
+Add any additional research or context that was conducted in creating this feature request.
+
+For example:
+- Related GitHub issues and PR's either within this repository or in other relevant repositories.
+- Specific links to specific lines or a focus within source code.
+- Relevant summary of Maintainers development meetings, milestones, projects, etc.
+- Any additional supplemental web references or links that would further justify this feature request.

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@ mym/
 *.env
 notebook
 *getSchema.m
-docker-compose.y*ml
+docker-compose*.y*ml
 .vscode
 matlab.prf
 win.*
 macos.*
 *.prj
 *.mltbx
+Jobs.m

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,3 +1,8 @@
+3.4.1 -- December 18, 2020
+--------------------------
+* Bugfix: Error on accessing unmanaged Imported/Computed tables (#336) PR #???
+* Bugfix: Certain characters in attribute comment not escaped properly (#210, #335) PR #???
+
 3.4.0 -- December 11, 2020
 --------------------------
 * Minor: Add dj.config to be compatible with dj-python and removed dj.set (#186) #188

--- a/tests/Prep.m
+++ b/tests/Prep.m
@@ -149,7 +149,11 @@ classdef Prep < matlab.unittest.TestCase
             subFolders = files(dirFlags);
             for k = 1 : length(subFolders)
                 delete([testCase.test_root '/test_schemas/' subFolders(k).name ...
-                    '/getSchema.m']);
+                        '/getSchema.m']);
+                if strcmp(subFolders(k).name, '+Lab')
+                    delete([testCase.test_root '/test_schemas/' subFolders(k).name ...
+                            '/Jobs.m']);
+                end
                 % delete(['test_schemas/+University/getSchema.m'])
             end
             warning('off','MATLAB:RMDIR:RemovedFromPath');

--- a/tests/TestSchema.m
+++ b/tests/TestSchema.m
@@ -103,5 +103,21 @@ classdef TestSchema < Prep
             dj.new('new.Student', 'M', pwd , 'djtest_new');
             rmdir('+new', 's');
         end
+        function TestSchema_testVirtual(testCase)
+            st = dbstack;
+            disp(['---------------' st(1).name '---------------']);
+            % setup
+            dj.config.restore;
+            package = 'Lab';
+            c1 = dj.conn(...
+                testCase.CONN_INFO.host, ...
+                testCase.CONN_INFO.user, ...
+                testCase.CONN_INFO.password,'',true);
+            dj.createSchema(package,[testCase.test_root '/test_schemas'], ...
+                [testCase.PREFIX '_' lower(package)]);
+            Lab.SessionAnalysis()
+            schema = dj.Schema(c1, package, [testCase.PREFIX '_' lower(package)]);
+            schema.v.SessionAnalysis()
+        end
     end
 end

--- a/tests/test_schemas/+University/Message.m
+++ b/tests/test_schemas/+University/Message.m
@@ -1,6 +1,6 @@
 %{
 # Message
-msg_id : uuid       # test comment?
+msg_id : uuid       # (this) is: a test of 'an' (elaborate), /type: of "comment" (good luck?)
 ---
 body : varchar(30)
 dep_id=null : uuid


### PR DESCRIPTION
- Resolves #336 issue of instantiating classes with abstract methods (`dj.Imported`, `dj.Computed`) by using super class `dj.internal.UserRelation` and parsing table name to determine table type. This use case is triggered when using the virtual class operation. Added `dj.ERD.getTier` utility method.
- Resolves #210, #335 by properly escaping `"` and `/` characters in attribute comments.
- Adds issue templates for bug reports and new feature requests.

This resolves the blocker that @ttngu207 reported related to Moser. Thinking to release `3.4.1` as introduced here and rename milestone from `3.4.1` -> `3.4.2` if others agree.

Fix #336
Fix #210
Fix #335