### PR TITLE
Add docker compose for mkdocs deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ mym/
 notebook
 *getSchema.m
 docker-compose*.y*ml
+!docs/docker-compose.yaml
 .vscode
 matlab.prf
 win.*

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -24,12 +24,13 @@ services:
       - -c
       - |
         set -e
+        export PATCH_VERSION=$$(cat /main/+dj/version.m | grep 'v =' | sed 's/[^0-9]*/./g' | cut -c 2-6)
         if echo "$${MODE}" | grep -i live &>/dev/null; then
             mkdocs serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
         elif echo "$${MODE}" | grep -iE "qa|build" &>/dev/null; then
             git branch -D gh-pages || true
             git fetch $${UPSTREAM_REPO} gh-pages:gh-pages || true
-            mike deploy --config-file ./docs/mkdocs.yaml -u $$(grep -oE '\d+\.\d+' /main/$${PACKAGE}/version.py) latest
+            mike deploy --config-file ./docs/mkdocs.yaml -u $PATCH_VERSION latest
             mike set-default --config-file ./docs/mkdocs.yaml latest
             if echo "$${MODE}" | grep -i qa &>/dev/null; then
                 mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,0 +1,40 @@
+# MODE="LIVE" PACKAGE=datajoint UPSTREAM_REPO=https://github.com/datajoint/datajoint-matlab.git HOST_UID=$(id -u) docker compose -f docs/docker-compose.yaml up --build
+#
+# navigate to http://localhost/
+version: "2.4"
+services:
+  docs:
+    build:
+      dockerfile: docs/.docker/Dockerfile
+      context: ../
+      args:
+        - PACKAGE
+    image: ${PACKAGE}-docs
+    environment:
+      - PACKAGE
+      - UPSTREAM_REPO
+      - MODE
+    volumes:
+      - ..:/main
+    user: ${HOST_UID}:anaconda
+    ports:
+      - 80:80
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        if echo "$${MODE}" | grep -i live &>/dev/null; then
+            mkdocs serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
+        elif echo "$${MODE}" | grep -iE "qa|build" &>/dev/null; then
+            git branch -D gh-pages || true
+            git fetch $${UPSTREAM_REPO} gh-pages:gh-pages || true
+            mike deploy --config-file ./docs/mkdocs.yaml -u $$(grep -oE '\d+\.\d+' /main/$${PACKAGE}/version.py) latest
+            mike set-default --config-file ./docs/mkdocs.yaml latest
+            if echo "$${MODE}" | grep -i qa &>/dev/null; then
+                mike serve --config-file ./docs/mkdocs.yaml -a 0.0.0.0:80
+            fi
+        else
+            echo "Unexpected mode..."
+            exit 1
+        fi


### PR DESCRIPTION
In my [previous PR](https://github.com/datajoint/datajoint-matlab/pull/417), I failed to realize the `.gitignore` excluded the docs docker compose. Here, I
- Add a line to the gitignore to permit this compose file specifically
- Add a docker compose file, which works in my local deployment

Note: tests will fail, as this is not the staging branch. I'm PRing here because of the precedent set by the previous docs PR