### PR TITLE
update problematic tls keyword

### DIFF
--- a/+dj/conn.m
+++ b/+dj/conn.m
@@ -91,7 +91,7 @@ else
     elseif islogical(use_tls) && use_tls
         use_tls = 'true';
     elseif ~isstruct(use_tls)
-        use_tls = 'none';
+        use_tls = 'false';
     else
         use_tls = jsonencode(use_tls);
     end


### PR DESCRIPTION
PR to fix https://github.com/datajoint/datajoint-matlab/issues/438#issuecomment-2476558347. 

Automatic access was broken when tls is not used for database connections. Previously used 'none' keyword resulted in a silent error, using 'false' instead (consistent with intended use), fixes the problem.

Let me know if you need anything else, happy to contribute.

